### PR TITLE
Change delay to 3 seconds and 4 seconds repectively

### DIFF
--- a/blink.ino
+++ b/blink.ino
@@ -18,7 +18,7 @@ void setup() {
 // the loop routine runs over and over again forever:
 void loop() {
   digitalWrite(led, HIGH);   // turn the LED on (HIGH is the voltage level)
-  delay(3000);               // wait for a second
+  delay(3000);               // wait for 3 seconds
   digitalWrite(led, LOW);    // turn the LED off by making the voltage LOW
-  delay(2000);               // wait for a second
+  delay(4000);               // wait for 4 seconds
 }


### PR DESCRIPTION
Studies have shown that 3 seconds is a far better LED delay than 1 second.Also I believe it would be better if the light was off for 4 seconds and on for just 3.